### PR TITLE
Small updates ...

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,5 +7,5 @@
 ^NOTES\.*html$
 ^\.codecov\.yml$
 ^README_files$
-^doc$
+^docs$
 ^tmp$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,6 @@ Imports:
     usethis,
     crayon,
     desc,
-    stats,
-    utils,
     rprojroot,
     magrittr
 RoxygenNote: 6.0.1.9000

--- a/inst/templates/detect.R
+++ b/inst/templates/detect.R
@@ -5,7 +5,7 @@ is_true <- function (x) identical(x, TRUE)
 detect <- function (.x, .f, ..., .right = FALSE, .p) {
 
   if (inherits(.f, "formula")) {
-    .body <- dimnames(attr(terms(.f), "factors"))[[1]]
+    .body <- dimnames(attr(stats::terms(.f), "factors"))[[1]]
     .f <- function(.x, .=.x) {}
     body(.f) <- as.expression(parse(text=.body))
   }
@@ -25,7 +25,7 @@ detect <- function (.x, .f, ..., .right = FALSE, .p) {
 detect_index <- function (.x, .f, ..., .right = FALSE, .p) {
 
   if (inherits(.f, "formula")) {
-    .body <- dimnames(attr(terms(.f), "factors"))[[1]]
+    .body <- dimnames(attr(stats::terms(.f), "factors"))[[1]]
     .f <- function(.x, .=.x) {}
     body(.f) <- as.expression(parse(text=.body))
   }

--- a/inst/templates/mappers.R
+++ b/inst/templates/mappers.R
@@ -16,7 +16,7 @@ map <- function(.x, .f, ..., .default) {
   default_exists <- !missing(.default)
 
   if (inherits(.f, "formula")) {
-    .body <- dimnames(attr(terms(.f), "factors"))[[1]]
+    .body <- dimnames(attr(stats::terms(.f), "factors"))[[1]]
     .f <- function(.x, . = .x) {}
     body(.f) <- as.expression(parse(text=.body))
   }
@@ -53,7 +53,7 @@ map2 <- function(.x, .y, .f, ..., .default) {
   default_exists <- !missing(.default)
 
   if (inherits(.f, "formula")) {
-    .body <- dimnames(attr(terms(.f), "factors"))[[1]]
+    .body <- dimnames(attr(stats::terms(.f), "factors"))[[1]]
     .f <- function(.x, .y, . = .x) {}
     body(.f) <- as.expression(parse(text=.body))
   }
@@ -73,33 +73,33 @@ map2 <- function(.x, .y, .f, ..., .default) {
 
 }
 
-map_chr <- function(.x, .f, ...) {
+map_chr <- function(.x, .f, ..., .default) {
   nm <- names(.x)
   out <- as.character((map(.x, .f, ..., .default = .default)))
   if (length(nm) > 0) set_names(out, nm) else out
 }
 
-map2_chr <- function(.x, .y, .f, ...) {
+map2_chr <- function(.x, .y, .f, ..., .default) {
   as.character(unlist(map2(.x, .y, .f, ..., .default = .default)))
 }
 
-map_lgl <- function(.x, .f, ...) {
+map_lgl <- function(.x, .f, ..., .default) {
   nm <- names(.x)
   out <- as.logical(unlist(map(.x, .f, ..., .default = .default)))
   if (length(nm) > 0) set_names(out, nm) else out
 }
 
-map2_lgl <- function(.x, .y, .f, ...) {
+map2_lgl <- function(.x, .y, .f, ..., .default) {
   as.logical(unlist(map2(.x, .y, .f, ..., .default = .default)))
 }
 
-map_dbl <- function(.x, .f, ...) {
+map_dbl <- function(.x, .f, ..., .default) {
   nm <- names(.x)
   out <- as.double(unlist(map(.x, .f, ..., .default = .default)))
   if (length(nm) > 0) set_names(out, nm) else out
 }
 
-map2_dbl <- function(.x, .y, .f, ...) {
+map2_dbl <- function(.x, .y, .f, ..., .default) {
   as.double(unlist(map2(.x, .y, .f, ..., .default = .default)))
 }
 
@@ -109,7 +109,7 @@ map_int <- function(.x, .f, ..., .default) {
   if (length(nm) > 0) set_names(out, nm) else out
 }
 
-map2_int <- function(.x, .y, .f, ...) {
+map2_int <- function(.x, .y, .f, ..., .default) {
   as.integer(unlist(map2(.x, .y, .f, ..., .default = .default)))
 }
 

--- a/inst/templates/walkers.R
+++ b/inst/templates/walkers.R
@@ -6,7 +6,7 @@
 walk <- function(.x, .f, ...) {
 
   if (inherits(.f, "formula")) {
-    .body <- dimnames(attr(terms(.f), "factors"))[[1]]
+    .body <- dimnames(attr(stats::terms(.f), "factors"))[[1]]
     .f <- function(.x, . = .x) {}
     body(.f) <- as.expression(parse(text=.body))
   }
@@ -25,7 +25,7 @@ walk <- function(.x, .f, ...) {
 walk2 <- function(.x, .y, .f, ...) {
 
   if (inherits(.f, "formula")) {
-    .body <- dimnames(attr(terms(.f), "factors"))[[1]]
+    .body <- dimnames(attr(stats::terms(.f), "factors"))[[1]]
     .f <- function(.x, .y, . = .x) {}
     body(.f) <- as.expression(parse(text=.body))
   }


### PR DESCRIPTION
Thanks for creating this awesome project!

I was using the mappers recently in a package, and noticed a few things that will remove notes in R CMD Check.

* Added the `stats::` prefix `terms()` calls.
* Added the missing `.default` argument to the mapper helpers, `map_chr()`, `map_int()`, etc. The argument was already in place for `map()`.
* Removed utils and stats packages from DESCRIPTION. When R CMD Check is run, there was previously a note that these packages were not being used. 
* Added the `docs` folder to the build ignore file.